### PR TITLE
Avoid reprocessing bytes for MySQL and SQLite engines

### DIFF
--- a/lib/sqlalchemy/dialects/mysql/base.py
+++ b/lib/sqlalchemy/dialects/mysql/base.py
@@ -2397,6 +2397,8 @@ class MySQLDialect(default.DefaultDialect):
 
     supports_native_enum = True
 
+    supports_native_bytes = True
+
     supports_sequences = False  # default for MySQL ...
     # ... may be updated to True for MariaDB 10.3+ in initialize()
 

--- a/lib/sqlalchemy/dialects/sqlite/pysqlite.py
+++ b/lib/sqlalchemy/dialects/sqlite/pysqlite.py
@@ -486,6 +486,7 @@ class _SQLite_pysqliteDate(DATE):
 class SQLiteDialect_pysqlite(SQLiteDialect):
     default_paramstyle = "qmark"
     supports_statement_cache = True
+    supports_native_bytes = True
 
     colspecs = util.update_copy(
         SQLiteDialect.colspecs,

--- a/lib/sqlalchemy/engine/default.py
+++ b/lib/sqlalchemy/engine/default.py
@@ -155,6 +155,8 @@ class DefaultDialect(Dialect):
     supports_native_enum = False
     supports_native_boolean = False
     supports_native_uuid = False
+    supports_native_bytes = False
+
     non_native_boolean_check_constraint = True
 
     supports_simple_order_by_label = True

--- a/lib/sqlalchemy/engine/interfaces.py
+++ b/lib/sqlalchemy/engine/interfaces.py
@@ -1013,6 +1013,13 @@ class Dialect(EventTarget):
     .. versionadded:: 2.0
 
     """
+    supports_native_bytes: bool
+    """indicates if Python bytes() objects are handled natively by the
+    driver for SQL bytes datatypes.
+
+    .. versionadded:: 2.0
+
+    """
 
     construct_arguments: Optional[
         List[Tuple[Type[Union[SchemaItem, ClauseElement]], Mapping[str, Any]]]

--- a/lib/sqlalchemy/sql/sqltypes.py
+++ b/lib/sqlalchemy/sql/sqltypes.py
@@ -934,6 +934,9 @@ class _Binary(TypeEngine[bytes]):
     # both sqlite3 and pg8000 seem to return it,
     # psycopg2 as of 2.5 returns 'memoryview'
     def result_processor(self, dialect, coltype):
+        if dialect.supports_native_bytes:
+            return None
+
         def process(value):
             if value is not None:
                 value = bytes(value)

--- a/test/dialect/mysql/test_types.py
+++ b/test/dialect/mysql/test_types.py
@@ -752,9 +752,7 @@ class TypeRoundTripTest(fixtures.TestBase, AssertsExecutionResults):
         reflected = Table("thebytes", MetaData(), autoload_with=connection)
 
         for table in bytes_table, reflected:
-            connection.execute(
-                table.insert().values([b"abc"])
-            )
+            connection.execute(table.insert().values([b"abc"]))
             row = connection.execute(table.select()).first()
             eq_(list(row), [b"abc"])
 

--- a/test/dialect/test_sqlite.py
+++ b/test/dialect/test_sqlite.py
@@ -300,7 +300,7 @@ class TestTypes(fixtures.TestBase, AssertsExecutionResults):
             connection.execute(
                 t.select().where(t.c.thebytes).order_by(t.c.id)
             ).fetchall(),
-            [(1, b'7\xe7\x9f')],
+            [(1, b"7\xe7\x9f")],
         )
 
 


### PR DESCRIPTION
Fixed typing issue where :meth:`_orm.PropComparator.and_` expressions would
not be correctly typed inside of loader options such as
:func:`_orm.selectinload`.

Fixes: sqlalchemy#9669
Change-Id: I874cb22c004e0a24f2b7f530fda542de2c4c6d3b<!-- Provide a general summary of your proposed changes in the Title field above -->

### Description
<!-- Describe your changes in detail -->

### Checklist
<!-- go over following points. check them with an `x` if they do apply, (they turn into clickable checkboxes once the PR is submitted, so no need to do everything at once)

-->

This pull request is:

- [ ] A documentation / typographical error fix
	- Good to go, no issue or tests are needed
- [ ] A short code fix
	- please include the issue number, and create an issue if none exists, which
	  must include a complete example of the issue.  one line code fixes without an
	  issue and demonstration will not be accepted.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.   one line code fixes without tests will not be accepted.
- [ ] A new feature implementation
	- please include the issue number, and create an issue if none exists, which must
	  include a complete example of how the feature would look.
	- Please include: `Fixes: #<issue number>` in the commit message
	- please include tests.

**Have a nice day!**
